### PR TITLE
Use proper locale.h header

### DIFF
--- a/cbits/glue/glue.c
+++ b/cbits/glue/glue.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <time.h>
 #ifndef _WIN32
-#include <xlocale.h>
+#include <locale.h>
 #endif
 #include <HsFFI.h>
 


### PR DESCRIPTION
`xlocale.h` is no longer available in `glibc` as of version 2.26, see https://sourceware.org/ml/libc-alpha/2017-08/msg00010.html