### PR TITLE
Allow ansi-terminal 0.10

### DIFF
--- a/mercury-api.cabal
+++ b/mercury-api.cabal
@@ -134,7 +134,7 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:       base >= 4.6 && < 5
-                     , ansi-terminal >= 0.6.2.3 && < 0.10
+                     , ansi-terminal >= 0.6.2.3 && < 0.11
                      , bytestring >= 0.10.4 && < 0.11
                      , clock >= 0.7.2 && < 0.9
                      , hashable >= 1.2.4 && < 1.4
@@ -155,7 +155,7 @@ executable tmr-params
   main-is:             tmr-params.hs
   other-modules:       ExampleUtil
   build-depends:       base >= 4.6 && < 5
-                     , ansi-terminal >= 0.6.2.3 && < 0.10
+                     , ansi-terminal >= 0.6.2.3 && < 0.11
                      , bytestring >= 0.10.4 && < 0.11
                      , mercury-api
                      , optparse-applicative >= 0.13 && < 0.15
@@ -182,7 +182,7 @@ executable tmr-read
   main-is:             tmr-read.hs
   other-modules:       ExampleUtil
   build-depends:       base >= 4.6 && < 5
-                     , ansi-terminal >= 0.6.2.3 && < 0.10
+                     , ansi-terminal >= 0.6.2.3 && < 0.11
                      , bytestring >= 0.10.4 && < 0.11
                      , mercury-api
                      , optparse-applicative >= 0.13 && < 0.15
@@ -196,7 +196,7 @@ executable tmr-write
   main-is:             tmr-write.hs
   other-modules:       ExampleUtil
   build-depends:       base >= 4.6 && < 5
-                     , ansi-terminal >= 0.6.2.3 && < 0.10
+                     , ansi-terminal >= 0.6.2.3 && < 0.11
                      , bytestring >= 0.10.4 && < 0.11
                      , mercury-api
                      , optparse-applicative >= 0.13 && < 0.15


### PR DESCRIPTION
https://github.com/commercialhaskell/stackage/issues/4798

The changes implemented in `ansi-terminal-0.10` do not affect this package.